### PR TITLE
[Design] 온보딩 페이지 하단에 개인정보 보호정책 추가

### DIFF
--- a/src/components/main/MainFooter.tsx
+++ b/src/components/main/MainFooter.tsx
@@ -1,0 +1,42 @@
+import { styled } from 'styled-components'
+
+const Container = styled.div`
+  background-color: #e3e3e3;
+  width: 100vw;
+  height: 20vh;
+  display: flex;
+`
+
+const Wraper = styled.div`
+  display: flex;
+  width: 80vw;
+  height: 10vh;
+  justify-content: center;
+  align-items: center;
+  margin: 0 auto;
+`
+
+const Text = styled.div`
+  display: flex;
+  font-size: 30px;
+  font-weight: bold;
+  color: #858585;
+  cursor: pointer;
+`
+
+function MainFooter() {
+  return (
+    <Container>
+      <Wraper>
+        <Text
+          onClick={() => {
+            window.open('https://www.termsfeed.com/live/1301ad52-4ab8-4ed9-aa9b-f93e9e23aa25')
+          }}>
+          개인정보 보호정책
+        </Text>
+      </Wraper>
+    </Container>
+  )
+}
+
+export default MainFooter

--- a/src/components/main/MainFourth.tsx
+++ b/src/components/main/MainFourth.tsx
@@ -10,7 +10,7 @@ interface OnboardProps {
 }
 
 const Container = styled.div`
-  background-color: #f4eef4;
+  background-color: #f7f7f7;
   width: 100vw;
   height: 100vh;
   position: relative;

--- a/src/components/main/MainSecond.tsx
+++ b/src/components/main/MainSecond.tsx
@@ -10,7 +10,7 @@ interface OnboardProps {
 }
 
 const Container = styled.div`
-  background-color: #f4eef4;
+  background-color: #f7f7f7;
   width: 100vw;
   height: 100vh;
   position: relative;

--- a/src/components/main/MainThird.tsx
+++ b/src/components/main/MainThird.tsx
@@ -10,7 +10,7 @@ interface OnboardProps {
 }
 
 const Container = styled.div`
-  background-color: #f7f7f7;
+  background-color: #f4eef4;
   width: 100vw;
   height: 100vh;
   position: relative;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -7,6 +7,7 @@ import MainFourth from '../components/main/MainFourth'
 import MainSecond from '../components/main/MainSecond'
 import MainThird from '../components/main/MainThird'
 import StartNav from '../components/main/StartNav'
+import MainFooter from '../components/main/MainFooter'
 
 const Container = styled.div`
   width: 100vw;
@@ -38,6 +39,7 @@ function MainPage() {
         <MainSecond />
         <MainThird />
         <MainFourth />
+        <MainFooter />
         <StartNav handleStart={handleStart} />
       </Container>
     </div>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -22,8 +22,8 @@ interface ApiUrlState {
   setApiUrl: (url: string) => void
 }
 export const useApiUrlStore = create<ApiUrlState>((set) => ({
-  // apiUrl: 'http://study-mate.kro.kr:8080/api',
-  apiUrl: 'https://study-mate.kro.kr/api',
+  apiUrl: 'http://study-mate.kro.kr:8080/api',
+  // apiUrl: 'https://study-mate.kro.kr/api',
   // apiUrl: 'http://localhost:8080/api',
   setApiUrl: (url: string) => set((state) => ({ ...state, apiUrl: url })),
 }))
@@ -55,4 +55,27 @@ interface UserList {
 export const useUserListStore = create<UserListState>((set) => ({
   userList: [],
   setUserList: (userList) => set({ userList }),
+}))
+
+/* 리뷰 리스트 */
+interface ReviewListState {
+  reviewList: ReviewList[]
+  setReviewList: (reviewList: ReviewList[]) => void
+}
+
+interface ReviewList {
+  reviewId: number
+  title: string
+  content: string
+  writer: string
+  mentor: string
+  star: number
+  isSolved: boolean
+  heart: boolean
+  createAt: string
+}
+
+export const useReviewListStore = create<ReviewListState>((set) => ({
+  reviewList: [],
+  setReviewList: (reviewList) => set({ reviewList }),
 }))


### PR DESCRIPTION
## 📢 기능 설명
- 온보딩 페이지 하단에 개인정보 보호정책 url 추가

필요시 실행결과 스크린샷 첨부
<br>
<img width="721" alt="image" src="https://github.com/TUK2024CD-Studymate/frontend/assets/83015089/7e7b9ac3-4fa6-4e98-9115-9d63335dcd62">
<img width="1429" alt="image" src="https://github.com/TUK2024CD-Studymate/frontend/assets/83015089/c0af3c65-c744-4b59-9c4d-ffd5053dd9b8">

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #102 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
