### PR TITLE
[feat] 온라인 매칭 질문 폼 수정 및 알고리즘 추가

### DIFF
--- a/src/components/SelectUser.tsx
+++ b/src/components/SelectUser.tsx
@@ -155,15 +155,33 @@ function SelectUser(id: any) {
   const parsedObject = JSON.parse(decodedValue)
   const question_id = parsedObject.id
 
-  // 멘토 리스트 조회
+  // // 멘토 리스트 조회
+  // const getUserList = async () => {
+  //   const access = localStorage.getItem('accessToken')
+  //   if (access) {
+  //     try {
+  //       const response = await axios.get(`${apiUrl}/matching/${question_id}`, {
+  //         headers: { Authorization: `Bearer ${access}` },
+  //       })
+  //       setUserList(response.data.memberList)
+  //       console.log('Success ', response.data)
+  //     } catch (error) {
+  //       console.error('Error ', error)
+  //     }
+  //   } else {
+  //     console.error('Access token not found.')
+  //   }
+  // }
+
+  // 멘토 리스트 조회(KMP)
   const getUserList = async () => {
     const access = localStorage.getItem('accessToken')
     if (access) {
       try {
-        const response = await axios.get(`${apiUrl}/matching/${question_id}`, {
+        const response = await axios.get(`${apiUrl}/matching/keyword/${question_id}`, {
           headers: { Authorization: `Bearer ${access}` },
         })
-        setUserList(response.data.memberList)
+        setUserList(response.data)
         console.log('Success ', response.data)
       } catch (error) {
         console.error('Error ', error)

--- a/src/components/SelectUser.tsx
+++ b/src/components/SelectUser.tsx
@@ -1,6 +1,11 @@
 import styled from 'styled-components'
 import { IoMdStar, IoMdHeartEmpty, IoIosContacts } from 'react-icons/io'
-import { useApiUrlStore, useReviewListStore, useUserListStore } from '../store/store'
+import {
+  useApiUrlStore,
+  useIsAiBasedStore,
+  useReviewListStore,
+  useUserListStore,
+} from '../store/store'
 import axios from 'axios'
 import ProfileIMG from '../assets/images/김영한.png'
 import { useEffect, useState } from 'react'
@@ -12,9 +17,9 @@ const Container = styled.div`
   justify-content: center;
   width: 1280px;
   height: 360px;
-  border: 3px solid #d8d8d8;
+  border: 2px solid #d8d8d8;
   &:hover {
-    border: 3px solid #650fa9;
+    border: 2px solid #650fa9;
   }
   margin-top: 15px;
   margin-bottom: 15px;
@@ -144,6 +149,7 @@ function SelectUser(id: any) {
   const { apiUrl } = useApiUrlStore()
   const { userList, setUserList } = useUserListStore()
   const { setReviewList } = useReviewListStore()
+  const { isAiBased } = useIsAiBasedStore()
   const [clickedUsername, setClickedUsername] = useState<string>() // 클릭한 유저 정보
 
   const [expandedUsers, setExpandedUsers] = useState<{ [key: number]: boolean }>({}) // 각 유저의 클릭 여부 상태
@@ -173,12 +179,14 @@ function SelectUser(id: any) {
   //   }
   // }
 
-  // 멘토 리스트 조회(KMP)
+  // 멘토 리스트 조회(KMP, AI)
   const getUserList = async () => {
     const access = localStorage.getItem('accessToken')
+    const urlPath = isAiBased ? '/matching/keyword/ai/' : '/matching/keyword/'
+
     if (access) {
       try {
-        const response = await axios.get(`${apiUrl}/matching/keyword/${question_id}`, {
+        const response = await axios.get(`${apiUrl}${urlPath}${question_id}`, {
           headers: { Authorization: `Bearer ${access}` },
         })
         setUserList(response.data)
@@ -341,3 +349,6 @@ function SelectUser(id: any) {
 }
 
 export default SelectUser
+function useIsAiBasedlStore(): { isAiBased: any } {
+  throw new Error('Function not implemented.')
+}

--- a/src/pages/OnlinePage/StartPage.tsx
+++ b/src/pages/OnlinePage/StartPage.tsx
@@ -101,6 +101,7 @@ function StartPage() {
   const [selectedOption, setSelectedOption] = useState<string | undefined>(undefined)
   const [title, setTitle] = useState<string>('')
   const [content, setContent] = useState<string>('')
+  const [specificField, setSpecificField] = useState<string>('')
   const [options] = useState<Option[]>([
     {
       label: 'PROGRAMMING',
@@ -124,7 +125,7 @@ function StartPage() {
   }
 
   const handleSpecificFieldChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setTitle(event.target.value)
+    setSpecificField(event.target.value)
   }
 
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -144,6 +145,7 @@ function StartPage() {
           {
             title: title,
             content: content,
+            specificField: specificField,
             interests: selectedOption,
           },
           {

--- a/src/pages/OnlinePage/StartPage.tsx
+++ b/src/pages/OnlinePage/StartPage.tsx
@@ -32,33 +32,40 @@ const StartWrap = styled.div`
 const Title = styled.div`
   font-size: 48px;
   font-weight: bold;
-  margin: 80px;
+  margin: 60px;
 `
 
 const SelectInterest = styled.select`
   border: solid 1px black;
-  width: 400px;
+  width: 600px;
   height: 70px;
   font-size: 28px;
-  margin: 20px;
+  margin: 10px;
   border-radius: 10px;
   padding: 10px;
 `
-const InputTitle = styled.input`
-  margin: 20px;
+
+const InputSpecificField = styled.input`
+  margin: 10px;
   border: solid 1px black;
   width: 600px;
   height: 70px;
   border-radius: 10px;
   padding: 10px;
   font-size: 28px;
-  ::placeholder {
-    color: BDBDBD; /* placeholder 텍스트 색상 설정 */
-    font-style: italic; /* placeholder 텍스트 스타일 설정 */
-  }
 `
 
-const InputContent = styled.input`
+const InputTitle = styled.input`
+  margin: 10px;
+  border: solid 1px black;
+  width: 600px;
+  height: 70px;
+  border-radius: 10px;
+  padding: 10px;
+  font-size: 28px;
+`
+
+const InputContent = styled.textarea`
   margin: 10px;
   border: solid 1px black;
   width: 600px;
@@ -66,10 +73,7 @@ const InputContent = styled.input`
   border-radius: 10px;
   padding: 10px;
   font-size: 28px;
-  ::placeholder {
-    color: BDBDBD; /* placeholder 텍스트 색상 설정 */
-    font-style: italic; /* placeholder 텍스트 스타일 설정 */
-  }
+  resize: none;
 `
 const StartMatchingBtn = styled.button`
   display: flex;
@@ -78,11 +82,11 @@ const StartMatchingBtn = styled.button`
   border-radius: 20px;
   font-size: 32px;
   font-weight: bold;
-  width: 320px;
-  height: 80px;
+  width: 240px;
+  height: 70px;
   background-color: #e8dcf2;
   color: #650fa9;
-  margin: 120px;
+  margin: 60px;
 `
 
 interface Option {
@@ -119,11 +123,15 @@ function StartPage() {
     setSelectedOption(event.target.value)
   }
 
+  const handleSpecificFieldChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value)
+  }
+
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setTitle(event.target.value)
   }
 
-  const handleContentChange = (event: ChangeEvent<HTMLInputElement>) => {
+  const handleContentChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     setContent(event.target.value)
   }
 
@@ -158,7 +166,7 @@ function StartPage() {
       <Navbar2 />
       <Container>
         <StartWrap>
-          <Title>질문에 맞는 멘토들을 추천 해드릴게요</Title>
+          <Title>질문에 맞는 멘토들을 추천해 드릴게요</Title>
           <SelectInterest value={selectedOption} onChange={handleOptionChange}>
             <option value="">관심분야를 선택하세요</option>
             {options.map((option) => (
@@ -167,11 +175,14 @@ function StartPage() {
               </option>
             ))}
           </SelectInterest>
-          <InputTitle placeholder="제목을 적어주세요" onChange={handleTitleChange}></InputTitle>
-          <InputContent
-            placeholder="내용을 적어주세요"
-            onChange={handleContentChange}></InputContent>
-          <StartMatchingBtn onClick={handleSubmit}>온라인 매칭 시작하기</StartMatchingBtn>
+          <InputSpecificField
+            placeholder="상세분야 ex)백엔드 JPA DB"
+            onChange={handleTitleChange}></InputSpecificField>
+          <InputTitle
+            placeholder="제목 ex)mysql spring 연동"
+            onChange={handleSpecificFieldChange}></InputTitle>
+          <InputContent placeholder="내용" onChange={handleContentChange}></InputContent>
+          <StartMatchingBtn onClick={handleSubmit}>멘토 찾기</StartMatchingBtn>
         </StartWrap>
         {/* <SelectUserModal /> */}
         {/* <ConfirmMatchingModal /> */}

--- a/src/pages/OnlinePage/StartPage.tsx
+++ b/src/pages/OnlinePage/StartPage.tsx
@@ -7,7 +7,7 @@ import Navbar2 from '../../components/Navbar2'
 // import FindLoadingModal from '../../components/FindLoadingModal'
 // import MatchingLoadingModal from '../../components/MatchingLoadingModal'
 import axios from 'axios'
-import { useApiUrlStore } from '../../store/store'
+import { useApiUrlStore, useIsAiBasedStore } from '../../store/store'
 import { useNavigate } from 'react-router-dom'
 
 const Container = styled.div`
@@ -75,6 +75,15 @@ const InputContent = styled.textarea`
   font-size: 28px;
   resize: none;
 `
+
+const BtnWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 600px;
+  height: 70px;
+  margin: 60px;
+`
 const StartMatchingBtn = styled.button`
   display: flex;
   justify-content: center;
@@ -86,7 +95,7 @@ const StartMatchingBtn = styled.button`
   height: 70px;
   background-color: #e8dcf2;
   color: #650fa9;
-  margin: 60px;
+  margin: 20px;
 `
 
 interface Option {
@@ -95,6 +104,7 @@ interface Option {
 
 function StartPage() {
   const { apiUrl } = useApiUrlStore()
+  const { setIsAiBased } = useIsAiBasedStore()
 
   const navigate = useNavigate()
 
@@ -136,29 +146,30 @@ function StartPage() {
     setContent(event.target.value)
   }
 
-  const handleSubmit = async () => {
+  const handleSubmit = async (useAi: boolean) => {
+    setIsAiBased(useAi) // AI 사용 여부 설정
     const access = localStorage.getItem('accessToken')
     if (access) {
       try {
         const response = await axios.post(
           `${apiUrl}/question`,
           {
-            title: title,
-            content: content,
-            specificField: specificField,
+            title,
+            content,
+            specificField,
             interests: selectedOption,
           },
           {
             headers: { Authorization: `Bearer ${access}` },
           },
         )
-        alert('Question created')
+        alert('질문이 생성되었습니다.')
         navigate('/online/select', { state: response.data.id })
       } catch (error) {
-        console.error('Error creating question:', error)
+        console.error('질문 생성 중 오류 발생:', error)
       }
     } else {
-      console.error('Access token not found.')
+      console.error('액세스 토큰이 없습니다.')
     }
   }
 
@@ -184,7 +195,12 @@ function StartPage() {
             placeholder="제목 ex)mysql spring 연동"
             onChange={handleSpecificFieldChange}></InputTitle>
           <InputContent placeholder="내용" onChange={handleContentChange}></InputContent>
-          <StartMatchingBtn onClick={handleSubmit}>멘토 찾기</StartMatchingBtn>
+          <BtnWrap>
+            <StartMatchingBtn onClick={() => handleSubmit(false)}>멘토 찾기</StartMatchingBtn>
+            <StartMatchingBtn onClick={() => handleSubmit(true)}>
+              AI 기반 멘토 찾기
+            </StartMatchingBtn>
+          </BtnWrap>
         </StartWrap>
         {/* <SelectUserModal /> */}
         {/* <ConfirmMatchingModal /> */}
@@ -196,3 +212,6 @@ function StartPage() {
 }
 
 export default StartPage
+function useIsAiBasedlStore(): { setIsAiBased: any } {
+  throw new Error('Function not implemented.')
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -166,3 +166,14 @@ export const useReviewListStore = create<ReviewListState>((set) => ({
   reviewList: [],
   setReviewList: (reviewList) => set({ reviewList }),
 }))
+
+/* 멘토 찾기 구분 */
+interface IsAiBasedState {
+  isAiBased: boolean
+  setIsAiBased: (isAiBased: boolean) => void
+}
+
+export const useIsAiBasedStore = create<IsAiBasedState>((set) => ({
+  isAiBased: false,
+  setIsAiBased: (isAiBased: boolean) => set({ isAiBased }),
+}))


### PR DESCRIPTION
## 📢 기능 설명

- KMP 매칭 추가
- AI 매칭 추가
- 매칭 추가에 따른 질문 폼 수정
- 두가지 매칭에 따른 api 요청 구분
- 매칭 구분은 전역 state 로 관리
 

필요시 실행결과 스크린샷 첨부
<br>
### 요청 폼
<img width="1427" alt="image" src="https://github.com/TUK2024CD-Studymate/frontend/assets/83015089/dd5aae4f-8c62-4412-94f7-3e36a1e1027c">

### 일반 매칭(KMP)
<img width="1437" alt="image" src="https://github.com/TUK2024CD-Studymate/frontend/assets/83015089/aafc942f-d8e6-4b78-9031-1cb1f5954b87">

### AI 매칭
<img width="1435" alt="image" src="https://github.com/TUK2024CD-Studymate/frontend/assets/83015089/f8046a88-c040-4181-9c60-4d3144b72a4a">






## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #125 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
