### PR TITLE
[Feat] Header 프로필 이미지와 닉네임 캐싱처리

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -62,8 +62,8 @@ const SignOut = styled.div`
 export default function Header() {
   const { apiUrl } = useApiUrlStore()
   const navigate = useNavigate()
-  const [nickname, setNickname] = useState<string>('')
-  const [profileimg, setProfileImg] = useState<string>('')
+  const [nickname, setNickname] = useState<string>(localStorage.getItem('nickname') || '')
+  const [profileimg, setProfileImg] = useState<string>(localStorage.getItem('profileUrl') || '')
 
   const getProfile = async () => {
     try {
@@ -119,6 +119,8 @@ export default function Header() {
 
     localStorage.removeItem('accessToken')
     localStorage.removeItem('refreshToken')
+    localStorage.removeItem('profileUrl')
+    localStorage.removeItem('nickname')
     navigate('/')
   }
   return (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import LogoImg from '../assets/images/StudyMate.svg'
 import defaultImg from '../assets/images/profileimg.png'
 import axios from 'axios'
-import { useApiUrlStore, useProfileDataStore, getImageImageUrl } from '../store/store'
+import { useApiUrlStore} from '../store/store'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
@@ -62,8 +62,7 @@ const SignOut = styled.div`
 export default function Header() {
   const { apiUrl } = useApiUrlStore()
   const navigate = useNavigate()
-  const [nickname, setNickname] = useState<string>(localStorage.getItem('nickname') || '')
-  const [profileimg, setProfileImg] = useState<string>(localStorage.getItem('profileUrl') || '')
+  const [profileimg, setProfileImg] = useState<string>(localStorage.getItem('profileUrl')||'')
 
   const getProfile = async () => {
     try {
@@ -75,13 +74,8 @@ export default function Header() {
       const response = await axios.get(`${apiUrl}/user`, {
         headers: { Authorization: `Bearer ${access}` },
       })
-      setNickname(response.data.nickname)
-      
-      if(response.data.imageUrl === "프로필 사진이 없습니다"){
-        setProfileImg(defaultImg)
-      } else{
-        setProfileImg(response.data.imageUrl)
-      }
+      response.data.imageUrl === "프로필 사진이 없습니다" ? setProfileImg(defaultImg) : setProfileImg(response.data.imageUrl)
+       
     } catch (error) {
       console.error('Error fetching nickname:', error)
     }
@@ -128,7 +122,7 @@ export default function Header() {
       <Logo src={LogoImg} onClick={() => navigate('/')} />
       <RightWrapper>
             <Profile src={profileimg} />
-            <NickName>{nickname}</NickName>
+            <NickName>{localStorage.getItem('nickname')}</NickName>
         <Sir>님</Sir>
         <SignOut onClick={handleLogout}>로그아웃</SignOut>
       </RightWrapper>

--- a/src/pages/mypage/ProfilePage.tsx
+++ b/src/pages/mypage/ProfilePage.tsx
@@ -155,6 +155,13 @@ function ProfilePage() {
       })
       setLoading(true)
       setProfileData(response.data)
+
+      const profileurl = response.data.imageUrl
+      const nickname = response.data.nickname
+
+      localStorage.setItem('profileUrl', profileurl)
+      localStorage.setItem('nickname', nickname)
+
     } catch (error) {}
   }
 

--- a/src/pages/mypage/UpdateProfilePage.tsx
+++ b/src/pages/mypage/UpdateProfilePage.tsx
@@ -247,9 +247,6 @@ function UpdateProfilePage() {
     }
   };
 
-  useEffect(() => {
-    getProfile()
-  }, [])
 
   
 


### PR DESCRIPTION
## 📢 기능 설명
- 헤더의 닉네임과 프로필 이미지 localStorage에 저장하여 캐싱처리
- 로그아웃 시 localStorage에서 삭제 

+ 질문사항
`<NickName>{localStorage.getItem('nickname')}</NickName>` 
이렇게 LocalStroage.getItem을 컴포넌트 값으로 가져와서 렌더링 해도 괜찮은가요? 닉네임 변경시 헤더에도 바로 적용될 수 있게 작성했는데 괜찮은 코드인지 잘 모르겠어서 물어봅니다...!
<br>

## 연결된 issue

연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #158 
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?
